### PR TITLE
Make terms configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: ./
+      with:
+        terms: "wip|fix|fixme"
       env:
         ENVIRONMENT: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git:1.0.7
 
 LABEL com.github.actions.name="FIXME check"
-LABEL com.github.actions.description="Check your code for `FIXME` labels"
+LABEL com.github.actions.description="Check code for specific terms (FIXME, WIP, etc.) and fail (with code annotations) if any are found."
 LABEL com.github.actions.icon="code"
 LABEL com.github.actions.color="yellow"
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ jobs:
 - I am using `FIXME:` here.
 - Nothing to see here.
 - I am using `FIX:` here.
-- I am using `wip:` here.
-- I am using `fixme:` here.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ jobs:
     - uses: bbugh/action-fixme-check@master # or @ the latest release
       with:
       	terms: 'WIP|FIXME' # optional, defaults to `FIXME`
-      	case-sensitive: false  # optional, defaults to `false`
 ```
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # action-fixme-check
 
-Checks the code base for any `FIXME:` (with the colon) and fails the check if
-any are found. Useful if you want to make sure that you don't miss any required
-changes in the code base before merging a PR.
+Checks the code base for any terms ending with a colon, and fail the check if
+any are found. The default term is `FIXME:`. You can add or change the terms
+using the `term` parameter, see [Installation](#Installation) below. 
+Useful if you want to make sure that you don't miss any required changes in the 
+code base before merging a PR.
 
 It runs very fast, taking only a few seconds to finish even on a very large
 codebase. All files in the repository will be read, including binary files (it
@@ -30,11 +32,25 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: bbugh/action-fixme-check@master # or @ the latest release
+      with:
+      	terms: 'WIP|FIXME' # optional, defaults to `FIXME`
+      	case-sensitive: false  # optional, defaults to `false`
 ```
 
 ## Support
 
 - [Official workflow configuration docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions)
+
+## Testing words
+
+(Used for testing this action on itself.)
+
+- I am using `WIP:` here.
+- I am using `FIXME:` here.
+- Nothing to see here.
+- I am using `FIX:` here.
+- I am using `wip:` here.
+- I am using `fixme:` here.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -12,3 +12,4 @@ inputs:
     description: 'The pipe-delimited searchable terms to pass as a regex group to `git grep`.'
     required: false
     default: "FIXME"
+

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'FIXME alert'
-description: 'Check code for `FIXME:` and fail (with annotations) if any are found.'
+description: 'Check code for specific terms (FIXME, WIP, etc.) and fail (with code annotations) if any are found.'
 author: '@bbugh'
 branding:
   icon: 'list'  
@@ -7,3 +7,8 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  terms:
+    description: 'The pipe-delimited searchable terms to pass as a regex group to `git grep`.'
+    required: false
+    default: "FIXME"

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -9,7 +9,7 @@ cp /git-grep-problem-matcher.json "$matcher_path"
 echo "::add-matcher::git-grep-problem-matcher.json"
 
 tag=${INPUT_TERMS:=FIXME}
-result=$(git grep --no-color --ignore-case --line-number --extended-regexp -e "(${tag})+(:)" :^.github)
+result=$(git grep --no-color --line-number --extended-regexp -e "(${tag})+(:)" :^.github)
 
 echo "${result}"
 

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -8,8 +8,8 @@ cp /git-grep-problem-matcher.json "$matcher_path"
 
 echo "::add-matcher::git-grep-problem-matcher.json"
 
-tag="FIXME"
-result=$(git grep --no-color -n -e "${tag}:")
+tag=${INPUT_TERMS:=FIXME}
+result=$(git grep --no-color --ignore-case --line-number --extended-regexp -e "(${tag})+(:)" :^.github)
 
 echo "${result}"
 


### PR DESCRIPTION
- This PR add the ability to configure the term/terms we are looking for inside our code, 
- while also ignoring the `.github` directory.
- The default value for the `terms` is `FIXME` (for backward compatibly).

## Example

```yml
name: Linters

on: [push]

jobs:
  fixmes:
    name: FIXME check
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - uses: bbugh/action-fixme-check@master # or @ the latest release
      with:
      	terms: 'wip|fixme'
```

> **Note**
> I added a few test statements to the README file, so feel free to remove them.

This PR should close #2 once it is merged.

![image](https://user-images.githubusercontent.com/27624/174563559-6ac02e17-ada6-473a-baea-581af1d6becb.png)
