### PR TITLE
feat: :sparkles: pass additional pathspec with action arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jobs:
       with:
       	terms: 'WIP|FIXME' # optional, defaults to `FIXME`
       	case-sensitive: false  # optional, defaults to `true`
+        pathspec: ':^dir-with-fixme' # optional, defaults to '.', see https://git-scm.com/docs/gitglossary#def_pathspec
 ```
 
 ## Support

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.case-sensitive }}
+    - ${{ inputs.pathspec }}
 inputs:
   terms:
     description: "The pipe-delimited searchable terms to pass as a regex group to `git grep`."
@@ -18,3 +19,7 @@ inputs:
     description: "Whether the searchable terms passed to `git grep` should be case-sensitive or not."
     required: false
     default: true
+  pathspec:
+    description: "additional pathspec argument for the `git-grep` command, see https://git-scm.com/docs/gitglossary#def_pathspec"
+    required: false
+    default: "."

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -10,6 +10,7 @@ echo "::add-matcher::git-grep-problem-matcher.json"
 
 
 case_sensitive="${1}"
+pathspec="${2}"
 
 if [ ${case_sensitive} = false ]; then
 	case_sensitive="--ignore-case"
@@ -19,7 +20,7 @@ fi
 
 
 tag=${INPUT_TERMS:=FIXME}
-result=$(git grep --no-color ${case_sensitive} --line-number --extended-regexp -e "(${tag})+(:)" :^.github)
+result=$(git grep --no-color ${case_sensitive} --line-number --extended-regexp -e "(${tag})+(:)" -- ":^.github" "${pathspec}")
 
 echo "${result}"
 


### PR DESCRIPTION
ref: #7

Testing:
1. create 2 files with fixme text (Readme.md and file-with-fixme-that-throw.md) https://github.com/akaguny/test-action-fixme-check
2. exclude README.md (.github excludes by default) https://github.com/akaguny/test-action-fixme-check/blob/main/.github/workflows/test.yaml#L13

**expected:**
only file-with-fixme-that-throw will throw Error
**actual:**
👌only file-with-fixme-that-throw will throw Error
https://github.com/akaguny/test-action-fixme-check/actions/runs/6989397876/job/19017976882
![image](https://github.com/bbugh/action-fixme-check/assets/3505959/b8834b8a-a27f-4057-8e77-8701ec53aced)

notes (for next devs maybe =) ):
* arguments available in bash script passed as $1, $2 order is matter and describe in action.yaml/runs/args
